### PR TITLE
Exporting the config vars

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,6 @@ set -e            # fail fast
 set -o pipefail   # don't ignore exit codes when piping output
 # set -x          # enable debugging
 
-build_env=${EMBER_ENV:-production}
 build_dir=$1
 cache_dir=$2
 env_dir=$3
@@ -12,6 +11,9 @@ buildpack_dir=$(cd $(dirname $0); cd ..; pwd)
 
 # Load some convenience functions like status(), echo(), and indent()
 source $buildpack_dir/bin/common.sh
+
+export_env_dir $env_dir
+build_env=${EMBER_ENV:-production}
 
 mkdir -p $build_dir/vendor
 


### PR DESCRIPTION
Although the recent changes to the code were accessing the `EMBER_ENV` config var, it was never actually being exported first.  Now calling the `export_env_dir` function before trying to access the `EMBER_ENV` variable
