### PR TITLE
Turn expires variable off

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -31,7 +31,6 @@ http {
     index index.html;
 
     location / {
-    
       expires off;
     
       if (!-e $request_filename){


### PR DESCRIPTION
So the index.html page won't be cached. I think this can be in the default configuration of the nginx server.
