### PR TITLE
No cache for index.html

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -52,6 +52,11 @@ http {
       }
     <% end %>
 
+    location ~* \index.html$ {
+      expires off;
+      <% if ENV["NGINX_DEBUG"] %>add_header X-Ember-Cli-Html on;<% end %>
+    }
+
     location ~* \.(ogg|ogv|svgz|mp4|css|rss|atom|js|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf|html|txt|htm)$ {
       expires max;
       log_not_found off;


### PR DESCRIPTION
I was experience some cache issues with my Ember app. Visitors always got their browser's cached version of the root index.html page.
