### PR TITLE
nginx configuration option to force https

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Have a staging server? Want to protect it with authentication? When `BASIC_AUTH_
 
 *Be sure to use `https` when you set this up for added security.*
 
+#### Force HTTPS
+
+For most Ember applications that make any kind of authenticated requests (sending an auth token with a request for example), HTTPS should be used. Enable this feature in nginx by setting `FORCE_HTTPS`.
+
+    heroku config:set FORCE_HTTPS=true
+
 ### Custom
 
 Need to make a custom nginx configuration change? No problem. In your Ember CLI application, add a `config/nginx.conf.erb` file. You can copy the existing configuration file in this repo and make your changes to it.

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,6 +35,12 @@ http {
     root dist;
     index index.html;
 
+    <% if ENV["FORCE_HTTPS"] %>
+      if ( $http_x_forwarded_proto != 'https' ) {
+        return 301 https://$host$request_uri;
+      }
+    <% end %>
+
     <% if ENV["BASIC_AUTH_USER"] && ENV["BASIC_AUTH_PASSWORD"] %>
       auth_basic "Restricted";
       auth_basic_user_file <%= "#{ENV["HOME"]}/config/htpasswd" %>;


### PR DESCRIPTION
I know that this was discussed in https://github.com/tonycoco/heroku-buildpack-ember-cli/issues/10, but I wanted to bring it up again for discussion.

This PR makes it easy to configuration a HTTP -> HTTPS redirect by setting the `FORCE_HTTPS` environment variable to true. Because this should be encouraged for most Ember applications that use some form of authentication to a backend API, I think it deserves to make it into the project directly. Any production deployment sending passwords or auth tokens should not ship without this.

Implementing it locally can also be a slight head-scratcher because you typically do the redirect this way when you have access to the `port` and `server_name`:

``` nginx
server {
    listen 80; 
    server_name example.com www.example.com;
    return 301 https://example.com$request_uri;
}

server {
    listen 443 ssl;
    ...
}
```

Thanks for taking a look!
