### PR TITLE
Added bower install prior to other dependencies to support addons

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,6 +105,10 @@ elif test -d $cache_dir/bower_components; then
   cp -r $cache_dir/bower_components $build_dir/
 fi
 
+status "Installing bower which is required by other dependencies"
+npm install bower --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+PATH=$build_dir/node_modules/bower/bin:$PATH
+
 status "Installing dependencies"
 # Make npm output to STDOUT instead of its default STDERR
 npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent


### PR DESCRIPTION
I was unable to deploy my application that had the ember-cli-bootstrap addon because the post install script required bower which was not yet in the path.
