### PR TITLE
Turn on nginx gzip compression for javascript & css assets

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -14,6 +14,9 @@ http {
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
   gzip_comp_level 2;
   gzip_min_length 512;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
   server_tokens off;
 


### PR DESCRIPTION
Enable nginx [gzip compression](https://developers.google.com/speed/docs/insights/EnableCompression) for core `js` and `css` assets.

Statistics for the change in a moderately sized app:

| File | Before | After | Reduction |
| --- | --- | --- | --- |
| `vendor.css` | `71k` | `48.2k` | 32% |
| `app.css` | `184k` | `38.4k` | 79% |
| `vendor.js` | `663k` | `223k` | 66% |
| `app.js` | `260k` | `51.3k` | 80% |
