### PR TITLE
Installing bower globally.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,7 +105,7 @@ elif test -d $cache_dir/bower_components; then
 fi
 
 status "Installing bower which is required by other dependencies"
-npm install bower --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+npm install bower -g --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
 PATH=$build_dir/node_modules/bower/bin:$PATH
 
 if [ -d "$env_dir" ]; then


### PR DESCRIPTION
Is this even possible for a buildpack to do? If so, it'll allow Ember Addons like [ember-cli-bootstrap](https://www.npmjs.com/package/ember-cli-bootstrap) to use the bower command on their postinstall scripts:

`npm install` *output from Codeship*
```
...
> ember-cli-bootstrap@0.0.12 postinstall /home/rof/src/github.com/RentalGeek/portola/node_modules/ember-cli-bootstrap 
> bower install 
sh: 1: bower: not found npm http GET https://registry.npmjs.org/uglify-js
npm ERR! ember-cli-bootstrap@0.0.12 postinstall: `bower install` 
npm ERR! Exit status 127 
npm ERR! 
npm ERR! Failed at the ember-cli-bootstrap@0.0.12 postinstall script. 
npm ERR! This is most likely a problem with the ember-cli-bootstrap package, 
npm ERR! not with npm itself. 
npm ERR! Tell the author that this fails on your system: 
npm ERR! bower install
...
```