### PR TITLE
Only force https if FORCE_HTTPS is true

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -38,7 +38,7 @@ http {
     root dist;
     index index.html;
 
-    <% if ENV["FORCE_HTTPS"] %>
+    <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
       if ( $http_x_forwarded_proto != 'https' ) {
         return 301 https://$host$request_uri;
       }


### PR DESCRIPTION
Currently, setting FORCE_HTTPS to false is the same as setting it to true (or any other string)