### PR TITLE
Properly set the `Cache-Control` to `no-cache` for index.html

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -98,7 +98,7 @@ http {
     <% end %>
 
     location ~* \index.html$ {
-      expires off;
+      expires -1;
       <% if ENV["NGINX_DEBUG"] %>add_header X-Ember-Cli-Html on;<% end %>
     }
 
@@ -127,7 +127,7 @@ http {
     }
 
     location / {
-      expires off;
+      expires -1;
 
       <% if ENV["PRERENDER_HOST"] %>
         try_files $uri @prerender;


### PR DESCRIPTION
This prevents caching `index.html` across deploys so users get the latest
`index.html` and fingerprinted assets.

`index.html` was being cached so that after a deploy you would receive a cached file. It would require a full page refresh to get the latest code. I've been running this change in production for a while, and it solves the problem. `expires -1` [correctly sets `Cache-Control: no-cache`](http://nginx.org/en/docs/http/ngx_http_headers_module.html).