### PR TITLE
Moved after_hook after the build process

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -183,10 +183,10 @@ if test -d $build_dir/bower_components; then
   cp -r $build_dir/bower_components $cache_dir/
 fi
 
+status "Building Ember CLI application $build_env distribution"
+node_modules/ember-cli/bin/ember build --environment $build_env | indent
+
 if test -f $build_dir/hooks/after_hook.sh; then
   status "After hook detected. Running..."
   source $build_dir/hooks/after_hook.sh
 fi
-
-status "Building Ember CLI application $build_env distribution"
-node_modules/ember-cli/bin/ember build --environment $build_env | indent


### PR DESCRIPTION
- The after_hook may need the built app (Actually we are using it to deploy some assets)