### PR TITLE
Remove port from redirection

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -37,6 +37,7 @@ http {
     keepalive_timeout 5;
     root dist;
     index index.html;
+    port_in_redirect off;
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
       if ( $http_x_forwarded_proto != 'https' ) {


### PR DESCRIPTION
This caused me a big headache. I had a file at public/folder/index.html, and when I visited /folder from the main page of our site, I was redirected to the page, but with the Nginx listening port added on. Since nginx is running behind a Heroku reverse proxy, this is obviously undesirable and the page did not load.

This config change prevents the port Nginx is listening on from appearing in the URL during a redirect.