### PR TITLE
Support custom client_max_body_size

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -52,6 +52,10 @@ http {
     index index.html;
     port_in_redirect off;
 
+    <% if ENV["CLIENT_MAX_BODY_SIZE"] %>
+      client_max_body_size <% ENV["CLIENT_MAX_BODY_SIZE"] %>;
+    <% end %>
+
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
       if ($http_x_forwarded_proto != "https") {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
`client_max_body_size` is fairly low by default in nginx. This comes up frequently enough that I made it an env var. Usage example: `CLIENT_MAX_BODY_SIZE=20M`