### PR TITLE
Fix nginx client_max_body_size erb line

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -53,7 +53,7 @@ http {
     port_in_redirect off;
 
     <% if ENV["CLIENT_MAX_BODY_SIZE"] %>
-      client_max_body_size <% ENV["CLIENT_MAX_BODY_SIZE"] %>;
+      client_max_body_size <%= ENV["CLIENT_MAX_BODY_SIZE"] %>;
     <% end %>
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>


### PR DESCRIPTION
There needs to be an = in order to set the value. Without it, deploys fail and the value is not inserted from ENV.