### PR TITLE
Change ruby version in before_hook to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For an after build hook:
 ```bash
 #!/usr/bin/env bash
 
-export GEM_HOME=$build_dir/.gem/ruby/1.9.1
+export GEM_HOME=$build_dir/.gem/ruby/2.2.0
 export PATH=$GEM_HOME/bin:$PATH
 
 if test -d $cache_dir/ruby/.gem; then


### PR DESCRIPTION
I have a before hook that installs sass, that just started failing yesterday with the following messages

```
remote: -----> Before hook detected. Running...
remote: WARNING:  You don't have /tmp/build_cc71047275a4e3d2053b5732bc129d7f/.gem/ruby/2.2.0/bin in your PATH,
remote: 	  gem executables will not run.
remote: Successfully installed sass-3.4.13
remote: 1 gem installed
remote: -----> Caching ruby gems directory for future builds
remote: -----> Building Ember CLI application production distribution
remote:        version: 0.2.0
remote:        Could not find watchman, falling back to NodeWatcher for file system events
remote: [broccoli-ruby-sass] Error: spawn sass ENOENT
remote:        BuildingBuilding.Building..Building...BuildingBuilding.Build failed.
remote:        spawn sass ENOENT
remote:        Error: spawn sass ENOENT
remote:            at exports._errnoException (util.js:746:11)
remote:            at Process.ChildProcess._handle.onexit (child_process.js:1053:32)
remote:            at child_process.js:1144:20
remote:            at process._tickCallback (node.js:355:11)
```

The warning line pointed me to the fact that it was installing sass to `$build_dir/.gem/ruby/2.2.0` instead of the `$build_dir/.gem/ruby/1.9.1` directory that was in my path. Changing GEM_HOME to ruby 2.2.0 solved the issue for me.