### PR TITLE
Add HTTPS redirect support for CloudFlare

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Setting `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` in your Heroku application w
 
 ### Force HTTPS/SSL
 
-For most Ember applications that make any kind of authenticated requests HTTPS should be used. Enable this feature in Nginx by setting `FORCE_HTTPS`:
+For most Ember applications that make any kind of authenticated requests HTTPS should be used. It supports the headers `X-Forwarded-Proto` ([used by Heroku](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) and `CF-Visitor` ([used by CloudFlare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-HTTPS-traffic-with-Flexible-SSL-and-Apache-)). Enable this feature in Nginx by setting `FORCE_HTTPS`:
 
     heroku config:set FORCE_HTTPS=true
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -40,7 +40,29 @@ http {
     port_in_redirect off;
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
-      if ( $http_x_forwarded_proto != 'https' ) {
+      <%# Set default value for CloudFlare %>
+      set $cloudflare NO;
+      <%# This matches http and https ($http_cf_visitor: {"scheme": "https"})%>
+      if ($http_cf_visitor ~* 'http') {
+        set $cloudflare YES;
+      }
+      <%# Redirect when is matches "http" (with quotes) %>
+      if ($http_cf_visitor ~* '"http"') {
+        return 301 https://$host$request_uri;
+      }
+    
+      <%# Only redirect when CloudFlare is false %>
+      set $cloudflare_heroku "${cloudflare}";
+      <%# Test for Heroku header, this matches http and https %>
+      if ($http_x_forwarded_proto ~* 'http') {
+        set $cloudflare_heroku "${cloudflare_heroku}YES";
+      }
+      <%# Test for "https" (without quotes) in Heroku header %>
+      if ($http_x_forwarded_proto !~* 'https') {
+        set $cloudflare_heroku "${cloudflare_heroku}HTTP";
+      }
+      <%# Redirect when CloudFlare is false and Heroku http is true %>
+      if ($cloudflare_heroku = NOYESHTTP) {
         return 301 https://$host$request_uri;
       }
     <% end %>


### PR DESCRIPTION
As discussed in https://github.com/tonycoco/heroku-buildpack-ember-cli/issues/83 I added support for the CloudFlare SSL header. Updated the docs with links to the official documentation.