### PR TITLE
Add force HTTPS support for CloudFlare

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Setting `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` in your Heroku application w
 
 For most Ember applications that make any kind of authenticated requests HTTPS should be used. It supports the headers `X-Forwarded-Proto` ([used by Heroku](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) and `CF-Visitor` ([used by CloudFlare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-HTTPS-traffic-with-Flexible-SSL-and-Apache-)). Enable this feature in Nginx by setting `FORCE_HTTPS`:
 
-    heroku config:set FORCE_HTTPS=true
+    $ heroku config:set FORCE_HTTPS=true
 
 ### Prerender.io
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Setting `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` in your Heroku application w
 
 ### Force HTTPS/SSL
 
-For most Ember applications that make any kind of authenticated requests HTTPS should be used. Enable this feature in Nginx by setting `FORCE_HTTPS`:
+For most Ember applications that make any kind of authenticated requests HTTPS should be used. It supports the headers `X-Forwarded-Proto` ([used by Heroku](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) and `CF-Visitor` ([used by CloudFlare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-HTTPS-traffic-with-Flexible-SSL-and-Apache-)). Enable this feature in Nginx by setting `FORCE_HTTPS`:
 
-    $ heroku config:set FORCE_HTTPS=true
+    heroku config:set FORCE_HTTPS=true
 
 ### Prerender.io
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -57,7 +57,21 @@ http {
     <% end %>
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
-      if ($http_x_forwarded_proto != "https") {
+      set $cloudflare NO;
+      if ($http_cf_visitor ~* 'http') {
+        set $cloudflare YES;
+      }
+      if ($http_cf_visitor ~* '"http"') {
+        return 301 https://$host$request_uri;
+      }
+      set $cloudflare_heroku "${cloudflare}";
+      if ($http_x_forwarded_proto ~* 'http') {
+        set $cloudflare_heroku "${cloudflare_heroku}YES";
+      }
+      if ($http_x_forwarded_proto !~* 'https') {
+        set $cloudflare_heroku "${cloudflare_heroku}HTTP";
+      }
+      if ($cloudflare_heroku = NOYESHTTP) {
         return 301 https://$host$request_uri;
       }
     <% end %>


### PR DESCRIPTION
As discussed in https://github.com/tonycoco/heroku-buildpack-ember-cli/issues/83 I added support for the CloudFlare SSL header. Updated the docs with links to the official documentation.

I saw nowhere in the nginx config file comments, so I left the comments out of the pull request, I'll add it here so we can always find it.

```erb
<% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
  <%# Set default value for CloudFlare %>
  set $cloudflare NO;
  <%# This matches http and https ($http_cf_visitor: {"scheme": "https"})%>
  if ($http_cf_visitor ~* 'http') {
    set $cloudflare YES;
  }
  <%# Redirect when is matches "http" (with quotes) %>
  if ($http_cf_visitor ~* '"http"') {
    return 301 https://$host$request_uri;
  }

  <%# Only redirect when CloudFlare is false %>
  set $cloudflare_heroku "${cloudflare}";
  <%# Test for Heroku header, this matches http and https %>
  if ($http_x_forwarded_proto ~* 'http') {
    set $cloudflare_heroku "${cloudflare_heroku}YES";
  }
  <%# Test for "https" (without quotes) in Heroku header %>
  if ($http_x_forwarded_proto !~* 'https') {
    set $cloudflare_heroku "${cloudflare_heroku}HTTP";
  }
  <%# Redirect when CloudFlare is false and Heroku http is true %>
  if ($cloudflare_heroku = NOYESHTTP) {
    return 301 https://$host$request_uri;
  }
<% end %>
```