### PR TITLE
When installing NPM packages use the --no-optional flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Clean your project's dependencies:
     $ npm cache clear
     $ bower cache clean
     $ rm -rf node_modules bower_components
-    $ npm install
+    $ npm install --no-optional
     $ bower install
 
 Be sure to save any Bower or NPM resolutions. Now, let's build your Ember CLI application locally:

--- a/bin/compile
+++ b/bin/compile
@@ -155,7 +155,7 @@ fi
 
 status "Installing dependencies"
 # Make npm output to STDOUT instead of its default STDERR
-npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+npm install --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
 
 # Add the project's and ember-cli's dependencies' binaries to the PATH
 PATH=$build_dir/node_modules/.bin:$build_dir/node_modules/ember-cli/node_modules/.bin:$PATH


### PR DESCRIPTION
Ember-cli 1.13.5 (https://github.com/ember-cli/ember-cli/releases/tag/v1.13.5) recommends using:
``` npm install--no-optional``` to skip installing native libraries.  I believe this will speed up heroku installation significantly 

As far as I can tell most of these optional native packages are *very* optional particularly in a heroku non-developer environment.  If that is a bad assumption I can modify further to make this a build variable dependent action.