### PR TITLE
Force rebuilds of NPM and Bower packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ if test -d $build_dir/.gem; then
 fi
 ```
 
+### Force Rebuilds
+
+Sometimes it is necessary to rebuild NPM modules or Bower dependencies from scratch.  This can become necessary when updating Ember or EmberCLI midway through a project and cleaning the Bower and NPM caches doesn't always refresh the cache in the Dyno during the next deployment.  In those cases, here is a simple and clean way to force a rebuild.
+
+To force a rebuild of NPM modules *and* Bower dependencies:
+
+    heroku config:set REBUILD_ALL=true
+    git commit -am 'rebuild' --allow-empty
+    git push heroku master
+    heroku config:unset REBUILD_ALL
+
+To force a rebuild of just the NPM modules:
+
+    heroku config:set REBUILD_NODE_PACKAGES=true
+    git commit -am 'rebuild' --allow-empty
+    git push heroku master
+    heroku config:unset REBUILD_NODE_PACKAGES
+
+To force a rebuild of Bower dependencies:
+
+    heroku config:set REBUILD_BOWER_PACKAGES=true
+    git commit -am 'rebuild' --allow-empty
+    git push heroku master
+    heroku config:unset REBUILD_BOWER_PACKAGES
+
 ### Custom Nginx
 
 In your Ember CLI application, add a `config/nginx.conf.erb` file and add your own Nginx configuration.

--- a/bin/compile
+++ b/bin/compile
@@ -99,31 +99,56 @@ fi
 
 cd $build_dir
 
-# If node_modules directory is checked into source control then
-# rebuild any native deps. Otherwise, restore from the build cache.
-if test -d $build_dir/node_modules; then
-  status "Found existing node_modules directory; skipping cache"
-  status "Rebuilding any native dependencies"
-  npm rebuild 2>&1 | indent
-elif test -d $cache_dir/node/node_modules; then
-  status "Restoring node_modules directory from cache"
-  cp -r $cache_dir/node/node_modules $build_dir/
+# Scan for any REBUILD flags
+rebuild_node_packages_file="$env_dir/REBUILD_NODE_PACKAGES"
+rebuild_bower_packages_file="$env_dir/REBUILD_BOWER_PACKAGES"
+rebuild_all_file="$env_dir/REBUILD_ALL"
 
-  status "Pruning cached dependencies not specified in package.json"
-  npm prune 2>&1 | indent
+if [[ -f $rebuild_node_packages_file ]]; then
+  rebuild_node_packages=$(cat $rebuild_node_packages_file)
+fi
 
-  if test -f $cache_dir/node/.heroku/node-version && [ $(cat $cache_dir/node/.heroku/node-version) != "$node_version" ]; then
-    status "Node version changed since last build; rebuilding dependencies"
+if [[ -f $rebuild_bower_packages_file ]]; then
+  rebuild_bower_packages=$(cat $rebuild_bower_packages_file)
+fi
+
+if [[ -f $rebuild_all_file ]]; then
+  rebuild_all=$(cat $rebuild_all_file)
+fi
+
+if [[ ( -n $rebuild_all ) || ( -n $rebuild_node_packages ) ]]; then
+  status "Forcing rebuild of all all node_modules.  Bypassing node_modules cache_dir."
+else
+  # If node_modules directory is checked into source control then
+  # rebuild any native deps. Otherwise, restore from the build cache.
+  if test -d $build_dir/node_modules; then
+    status "Found existing node_modules directory; skipping cache"
+    status "Rebuilding any native dependencies"
     npm rebuild 2>&1 | indent
+  elif test -d $cache_dir/node/node_modules; then
+    status "Restoring node_modules directory from cache"
+    cp -r $cache_dir/node/node_modules $build_dir/
+
+    status "Pruning cached dependencies not specified in package.json"
+    npm prune 2>&1 | indent
+
+    if test -f $cache_dir/node/.heroku/node-version && [ $(cat $cache_dir/node/.heroku/node-version) != "$node_version" ]; then
+      status "Node version changed since last build; rebuilding dependencies"
+      npm rebuild 2>&1 | indent
+    fi
   fi
 fi
 
-# Restore bower_components from cache if it exists
-if test -d $build_dir/bower_components; then
-  status "Found existing bower_components directory; skipping cache"
-elif test -d $cache_dir/bower_components; then
-  status "Restoring bower_components directory from cache"
-  cp -r $cache_dir/bower_components $build_dir/
+if [[ ( -n $rebuild_all ) || ( -n $rebuild_bower_packages ) ]]; then
+  status "Forcing re-installation of all all bower_components.  Bypassing bower_components cache_dir."
+else
+  # Restore bower_components from cache if it exists
+  if test -d $build_dir/bower_components; then
+    status "Found existing bower_components directory; skipping cache"
+  elif test -d $cache_dir/bower_components; then
+    status "Restoring bower_components directory from cache"
+    cp -r $cache_dir/bower_components $build_dir/
+  fi
 fi
 
 status "Installing bower which is required by other dependencies"


### PR DESCRIPTION
Sometimes during major Ember or EmberCLI upgrades midway through a project, it becomes necessary to rebuild NPM or Bower components in the Heroku slug.  Unfortunately, clearing the NPM or Bower caches doesn't always do the trick.

This pull request allows the user to simply and easily push a NO/OP change to Heroku that forces a rebuild.

Rebuilds now are as easy as:

    heroku config:set REBUILD_ALL=true
    git commit -am 'rebuild' --allow-empty
    git push heroku master
    heroku config:unset REBUILD_ALL
