### PR TITLE
Add IP whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ To [purge the cache](https://github.com/heroku/heroku-repo#purge_cache) and rein
     $ heroku plugins:install https://github.com/heroku/heroku-repo.git
     $ heroku repo:purge_cache -a APPNAME
 
+### IP Whitelist
+
+Setting `IP_WHITELIST` in your Herkou application to a comma delimited list of IP addresses or CIDR blocks will restrict access to your application to only those values.
+
+    $ heroku config:set IP_WHITELIST=192.168.0.0/24,192.168.1.42
+
 ## Troubleshooting
 
 Clean your project's dependencies:

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -167,6 +167,14 @@ http {
     location / {
       expires -1;
 
+      <% if ENV["IP_WHITELIST"] %>
+        set_real_ip_from 10.0.0.0/8;
+        real_ip_header X-Forwarded-For;
+        <% ENV["IP_WHITELIST"].split(",").each do |ip| %>
+          allow <%= ip %>;
+        <% end %>
+        deny all;
+      <% end %>
       <% if ENV["PRERENDER_HOST"] %>
         try_files $uri @prerender;
       <% else %>


### PR DESCRIPTION
Setting `IP_WHITELIST` in your Herkou application to a comma delimited list of IP addresses or CIDR blocks will restrict access to your application to only those values.