### PR TITLE
Use `TRUSTED_PROTOCOL_HEADER` with `FORCE_HTTPS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ Setting `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` in your Heroku application w
 
 ### Force HTTPS/SSL
 
-For most Ember applications that make any kind of authenticated requests HTTPS should be used. It supports the headers `X-Forwarded-Proto` ([used by Heroku](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) and `CF-Visitor` ([used by CloudFlare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-HTTPS-traffic-with-Flexible-SSL-and-Apache-)). Enable this feature in Nginx by setting `FORCE_HTTPS`:
+For most Ember applications that make any kind of authenticated requests HTTPS should be used.  It supports the headers `X-Forwarded-Proto` ([used by Heroku](https://devcenter.heroku.com/articles/http-routing#heroku-headers)) and `CF-Visitor` ([used by CloudFlare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-HTTPS-traffic-with-Flexible-SSL-and-Apache-)).
 
-    $ heroku config:set FORCE_HTTPS=true
+This setting also requires setting `TRUSTED_PROTOCOL_HEADER` to `cf_visitor` for CloudFlare or `x_forwarded_proto` for Heroku.
+
+Enable this feature in Nginx by setting `FORCE_HTTPS` and `TRUSTED_PROTOCOL_HEADER`:
+
+    $ heroku config:set FORCE_HTTPS=true TRUSTED_PROTOCOL_HEADER=x_forwarded_proto
 
 ### Prerender.io
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -57,23 +57,11 @@ http {
     <% end %>
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
-      set $cloudflare NO;
-      if ($http_cf_visitor ~* 'http') {
-        set $cloudflare YES;
-      }
-      if ($http_cf_visitor ~* '"http"') {
-        return 301 https://$host$request_uri;
-      }
-      set $cloudflare_heroku "${cloudflare}";
-      if ($http_x_forwarded_proto ~* 'http') {
-        set $cloudflare_heroku "${cloudflare_heroku}YES";
-      }
-      if ($http_x_forwarded_proto !~* 'https') {
-        set $cloudflare_heroku "${cloudflare_heroku}HTTP";
-      }
-      if ($cloudflare_heroku = NOYESHTTP) {
-        return 301 https://$host$request_uri;
-      }
+      <% if ENV["TRUSTED_PROTOCOL_HEADER"] && !ENV["TRUSTED_PROTOCOL_HEADER"].empty? %>
+        if ($http_<%= ENV["TRUSTED_PROTOCOL_HEADER"] %> !~* 'https') {
+          return 301 https://$host$request_uri;
+        }
+      <% end %>
     <% end %>
 
     <% if ENV["BASIC_AUTH_USER"] && ENV["BASIC_AUTH_PASSWORD"] %>

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -57,11 +57,9 @@ http {
     <% end %>
 
     <% if ENV["FORCE_HTTPS"] && ENV["FORCE_HTTPS"] == "true" %>
-      <% if ENV["TRUSTED_PROTOCOL_HEADER"] && !ENV["TRUSTED_PROTOCOL_HEADER"].empty? %>
-        if ($http_<%= ENV["TRUSTED_PROTOCOL_HEADER"] %> !~* 'https') {
-          return 301 https://$host$request_uri;
-        }
-      <% end %>
+      if ($http_<%= ENV.fetch("TRUSTED_PROTOCOL_HEADER") %> !~* 'https') {
+        return 301 https://$host$request_uri;
+      }
     <% end %>
 
     <% if ENV["BASIC_AUTH_USER"] && ENV["BASIC_AUTH_PASSWORD"] %>


### PR DESCRIPTION
On Heroku, passing any value that matches the expression `/http/` in the "CF-Visitor" header bypasses SSL enforcement. This could be mitigated by setting and checking for the provider or forwarded protocol header in an environment variable.

I realize this is an unlikely occurrence, but there's no reason not to protect against it.