### PR TITLE
Make sure to use existing bower

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -153,14 +153,6 @@ else
   ln -s $cache_dir/bower_components $build_dir/bower_components
 fi
 
-if test -e $build_dir/node_modules/bower/bin/bower; then
-  status "Bower already exists"
-else
-  status "Installing bower which is required by other dependencies"
-  npm install bower@1.5.3 --save-dev --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
-fi
-
-PATH=$build_dir/node_modules/bower/bin:$PATH
 
 if [ "$GIT_SSH_KEY" != "" ]; then
   status "Detected SSH key for git.  launching ssh-agent and loading key"
@@ -182,12 +174,25 @@ fi
 status "Pruning cached dependencies not specified in package.json"
 npm prune 2>&1 | indent
 
-status "Pruning cached bower dependencies not specified in bower.json"
-bower prune 2>&1 | indent
 
 status "Installing dependencies"
 # Make npm output to STDOUT instead of its default STDERR
 npm install --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
+
+PATH=$build_dir/node_modules/.bin:$PATH
+
+if type bower > /dev/null 2>&1 || test -e $build_dir/node_modules/bower/bin/bower; then
+  status "Bower already exists"
+else
+  status "Installing bower which is required by other dependencies"
+  npm install bower --save-dev --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
+fi
+
+PATH=$build_dir/node_modules/bower/bin:$PATH
+
+status "Pruning cached bower dependencies not specified in bower.json"
+bower prune 2>&1 | indent
+
 bower install --quiet | indent
 
 # Add the project's and ember-cli's dependencies' binaries to the PATH


### PR DESCRIPTION
In the case where you use rebuild all bower will always fail install check.
This causes problems if you use shrinkwrap in combination with rebuild all.

The fix:
* Move bower installed check to after npm install
* Add node_modules/.bin to PATH
* Add check for bower using type function
* Set bower executable in path after installing