### PR TITLE
Add WhatsApp to prerender bots

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -101,7 +101,7 @@ http {
         <% end %>
 
         set $prerender 0;
-        if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot") {
+        if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|whatsapp") {
           set $prerender 1;
         }
         if ($args ~ "_escaped_fragment_") {


### PR DESCRIPTION
WhatsApp has currently link previews in their app, we want to show them the prerendered version of the page. I checked for their user agent and it looks like this

```
WhatsApp/2.12.15/i
```

So the keyword `whatsapp` should be good enough.