### PR TITLE
Add NGINX config fragments.

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -51,6 +51,7 @@ http {
     root dist;
     index index.html;
     port_in_redirect off;
+    include <%= ENV["HOME"] %>/config/nginx.d/*.conf;
 
     <% if ENV["CLIENT_MAX_BODY_SIZE"] %>
       client_max_body_size <%= ENV["CLIENT_MAX_BODY_SIZE"] %>;

--- a/config/nginx.d/README.md
+++ b/config/nginx.d/README.md
@@ -1,0 +1,16 @@
+# Extending NGINX configuration
+
+You can add snippets of NGINX configuration in this directory by creating files whose filenames end in `.conf`.  These files will be included in the `server` section of the configuration, above the buildpack customisations.
+
+For example, if you need to use a reverse proxy to include a special `/admin` section of your site:
+
+```
+location /admin {
+  proxy_pass https://my-app-admin.herokuapp.com/;
+  proxy_set_header Real-IP $remote_addr;
+  proxy_set_header Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header NginX-Proxy true;
+  proxy_ssl_session_reuse off;
+  proxy_redirect off;
+}
+```


### PR DESCRIPTION
Hi there.

Given that there seemed to be no middle ground between setting a few ENV vars or replacing the entire NGINX config, I thought it might be nice if we dynamically included a config directory that allows the buildpack user to add fragments of NGINX config without having to replace the buildpack config and potentially lose any further enhancements made by the community.

Therefore; I've added `config/nginx.d/` and an include line in the `server` declaration of the main NGINX config.  If you create a file ending in `.conf` and drop it in this directory then NGINX will include the config in it when it fires up.