### PR TITLE
Add support for LetsEncrypt via ACME_CHALLENGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ For most Ember applications that make any kind of authenticated requests HTTPS s
 
     $ heroku config:set FORCE_HTTPS=true
 
+### LetsEncrypt support
+
+Using `heroku config:set ACME_CHALLENGE=<challenge-phrase>` allows the app to respond correctly to the call from a manual `certbot` command that is used to generate a LetsEncrypt SSL certificate.
+
+Follow these steps to get your free SSL certificate installed. (Assumes you have [SNI-SSL](https://devcenter.heroku.com/articles/ssl-beta) installed on your app.)
+
+    $ sudo certbot certonly --email=<your-email-address> --manual -d <your-domain-name>
+    $ heroku config:set ACME_CHALLENGE='<challenge phrase returned from the above command>'
+    # copy fullchain.pem privkey.pem locally from the path certbot put them
+    $ heroku _certs:update fullchain.pem privkey.pem
+    $ heroku config:unset ACME_CHALLENGE
+
 ### Prerender.io
 
 [Prerender.io](https://prerender.io) allows your application to be crawled by search engines.

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -94,6 +94,13 @@ http {
       }
     <% end %>
 
+    <% if ENV["ACME_CHALLENGE"] %>
+      location ^~ /.well-known/acme-challenge/ {
+        return 200 '<%= ENV['ACME_CHALLENGE'] %>';
+        add_header Content-Type text/plain;
+      }
+    <% end %>
+
     <% if ENV["PRERENDER_HOST"] %>
       # Based on the official Prerender.io gist https://gist.github.com/thoop/8165802
       location @prerender {


### PR DESCRIPTION
This allows Nginx to respond correctly to `.well-known/acme-challenge` that is invoked from the Let's Encrypt `certbot` command. By setting the `ACME_CHALLENGE` env var, and following the steps outlined in the updated README, it becomes a simple process to add/renew a Let's Encrypt SSL certificate.