### PR TITLE
Custom nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ To force a rebuild of Bower dependencies:
 
 ### Custom Nginx
 
+You can install a custom build of Nginx by setting the $NGINX_URL:
+
+    $ heroku config:set NGINX_URL=<the url to your custom build of nginx>
+
+Without this set, the version of Nginx installed will be 1.6.0.
+
+### Custom Nginx config
+
 In your Ember CLI application, add a `config/nginx.conf.erb` file and add your own Nginx configuration.
 
 *You should copy the existing configuration file in this repo and make changes to it for best results.*

--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,7 @@ else
 fi
 
 status "Downloading and installing nginx"
-nginx_url=https://s3.amazonaws.com/devmynd-github/heroku-nginx-1.6.0.tar.gz
+nginx_url=${NGINX_URL:-https://s3.amazonaws.com/devmynd-github/heroku-nginx-1.6.0.tar.gz}
 curl $nginx_url -s -o - | tar xzf - -C $build_dir/vendor
 
 status "Adding boot script"


### PR DESCRIPTION
This allows you to set a custom NGINX_URL so you can download a later version of nginx built on Heroku. 

The process for building on Heroku is a bit involved, but the steps are below (for anyone else wanting to do it):

* add the latest nginx build to your repo (download from https://nginx.org/en/download.html) and deploy to Heroku
* `heroku run bash` and un-tar.
* build using:
```
cd <location of untar'd nginx dist>
./configure
make
```
* scp the built binary (nginx) to another server
* scp off that other server to local machine
* download the tar that this buildpack installs by default (https://s3.amazonaws.com/devmynd-github/heroku-nginx-1.6.0.tar.gz)
* replace the nginx binary with the newly built binary from Heroku, re-tar and upload to your own S3 bucket, making it public. 
* set NGINX_URL to the S3 link to the new tar
* Redeploy
* ...
* Profit!

These steps probably need a Wiki entry, or similar, that is linked to from the README.md?