### PR TITLE
Proper way to install heroku-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Note: A recent change to the buildpack has made caching much more aggressive. If you are having trouble deploying run...
 
     $ heroku config:set REBUILD_ALL=true
-    $ heroku plugins:install https://github.com/heroku/heroku-repo.git
+    $ heroku plugins:install heroku-repo
     $ heroku repo:purge_cache -a APPNAME
 
 Be sure to replace `APPNAME` with your app's name. Now, push your repo up. Once that build is complete, your dependencies are rebuilt and cached. Now, unset the var...


### PR DESCRIPTION
Installing heroku repo via
```
 heroku plugins:install https://github.com/heroku/heroku-repo.git 
```

 will end up here
```
 !    `repo` is not a heroku command.
```
The correct way is 

heroku plugins:install heroku-repo

https://github.com/heroku/heroku-repo/issues/40