### PR TITLE
Remove word official from reference to heroku buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WARNING! This buildpack has been deprecated!
 
-Please use the official Heroku buildpack here: https://github.com/heroku/heroku-buildpack-emberjs
+Please use the Heroku buildpack here: https://github.com/heroku/heroku-buildpack-emberjs
 
 # Notes
 


### PR DESCRIPTION
It's a small thing, but _techincally_ the heroku ember buildpack is not one of Heroku's official buildpacks.  It is instead an open source initiative we are trying out while evaluating how best to more officially support ember and other single pages apps on our platform.  We are still excited to get people using and contributing to our buildpack, but we want to set expectations appropriately.