### PR TITLE
adds yarn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ Setting `IP_WHITELIST` in your Herkou application to a comma delimited list of I
 
     $ heroku config:set IP_WHITELIST=192.168.0.0/24,192.168.1.42
 
+### Yarn
+
+The Ember CLI buildpack supports yarn. If a `yarn.lock` file is present, the buildpack will use `yarn install` instead of `npm install`.
+
+If a specific version of yarn is specified in `engines.yarn` within your `package.json`, it will use that version. Otherwise it will install the latest version.
+
 ## Troubleshooting
 
 Clean your project's dependencies:

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -41,3 +41,13 @@ export_env_dir() {
     done
   fi
 }
+
+needs_resolution() {
+  local semver=$1
+  if ! [[ "$semver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+

--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,8 @@ bp_dir=$(cd $(dirname $0); cd ..; pwd)
 unset GIT_DIR
 # Load some convenience functions like status(), echo(), and indent()
 source $bp_dir/bin/common.sh
+# Load functions for yarn compatibility
+source $bp_dir/bin/yarn.sh
 
 status "Exporting config vars to environment"
 export_env_dir $env_dir
@@ -174,26 +176,49 @@ fi
 status "Pruning cached dependencies not specified in package.json"
 npm prune 2>&1 | indent
 
-
 status "Installing dependencies"
-# Make npm output to STDOUT instead of its default STDERR
-npm install --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
 
-PATH=$build_dir/node_modules/.bin:$PATH
 
-if type bower > /dev/null 2>&1 || test -e $build_dir/node_modules/bower/bin/bower; then
-  status "Bower already exists"
-else
-  status "Installing bower which is required by other dependencies"
-  npm install bower --save-dev --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
+[ -f "$build_dir/bower.json" ] && use_bower=true || use_bower=false
+# we install bower before "yarn install", because a common practice is to have
+# a "postinstall": "bower install" step in package.json which would get run
+# after "yarn install"
+if $use_bower; then
+  status "Detected bower.json"
+
+  PATH=$build_dir/node_modules/.bin:$PATH
+
+  if type bower > /dev/null 2>&1 || test -e $build_dir/node_modules/bower/bin/bower; then
+    status "Bower already exists"
+  else
+    status "Installing bower which is required by other dependencies"
+    npm install bower --save-dev --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
+  fi
 fi
 
-PATH=$build_dir/node_modules/bower/bin:$PATH
+if [ -f "$build_dir/yarn.lock" ]; then
+  status "Detected yarn.lock, installing yarn"
 
-status "Pruning cached bower dependencies not specified in bower.json"
-bower prune 2>&1 | indent
+  install_yarn
 
-bower install --quiet | indent
+  echo "Installing node modules using yarn"
+  cd $build_dir
+  yarn install --pure-lockfile --ignore-engines 2>&1
+else
+  status "Installing node modules using npm"
+
+  # Make npm output to STDOUT instead of its default STDERR
+  npm install --quiet --no-optional --userconfig $build_dir/.npmrc 2>&1 | indent
+fi
+
+if $use_bower; then
+  PATH=$build_dir/node_modules/bower/bin:$PATH
+
+  status "Pruning cached bower dependencies not specified in bower.json"
+  bower prune 2>&1 | indent
+
+  bower install --quiet | indent
+fi
 
 # Add the project's and ember-cli's dependencies' binaries to the PATH
 PATH=$build_dir/node_modules/.bin:$build_dir/node_modules/ember-cli/node_modules/.bin:$PATH

--- a/bin/yarn.sh
+++ b/bin/yarn.sh
@@ -1,0 +1,30 @@
+install_yarn() {
+  local dir="$build_dir/.heroku/yarn"
+  # Look in package.json's engines.yarn field for a semver range
+  local version=$($bp_dir/vendor/jq -r .engines.yarn $build_dir/package.json)
+
+  if needs_resolution "$version"; then
+    echo "Resolving yarn version ${version:-(latest)} via semver.io..."
+    local version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/yarn/resolve)
+  fi
+
+  echo "Downloading and installing yarn ($version)..."
+  local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
+  local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  if [ "$code" != "200" ]; then
+    echo "Unable to download yarn: $code" && false
+  fi
+  rm -rf $dir
+  mkdir -p "$dir"
+  # https://github.com/yarnpkg/yarn/issues/770
+  if tar --version | grep -q 'gnu'; then
+    tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1 --warning=no-unknown-keyword
+  else
+    tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1
+  fi
+  chmod +x $dir/bin/*
+
+  PATH=$build_dir/.heroku/yarn/bin:$PATH
+
+  echo "Installed yarn $(yarn --version)"
+}


### PR DESCRIPTION
I recognize this repo has been deprecated, however it seems the heroku build pack was not a drop in replacement for us. I might do a p.r. to that repo as well.

In case someone needs a patch get yarn suppor to their existing tonycoco version of the build pack, they can use this.

resolves: https://github.com/tonycoco/heroku-buildpack-ember-cli/issues/139

uses pieces of https://github.com/heroku/heroku-buildpack-nodejs.git to get yarn support.